### PR TITLE
Follow up for perfectqueue v0.8.41

### DIFF
--- a/lib/perfectsched.rb
+++ b/lib/perfectsched.rb
@@ -35,7 +35,10 @@ module PerfectSched
     :ScheduleWithMetadata => 'perfectsched/schedule',
     :ScheduleMetadata => 'perfectsched/schedule_metadata',
     :ScheduleMetadataAccessors => 'perfectsched/schedule_metadata',
+    # SignalQueue is obsolete because it does not run with ruby >= 2.0.0.
+    # See ddbf04c9 and use SignalThread instead.
     :SignalQueue => 'perfectsched/signal_queue',
+    :SignalThread => 'perfectsched/signal_thread',
     :Task => 'perfectsched/task',
     :Worker => 'perfectsched/worker',
     :VERSION => 'perfectsched/version',

--- a/lib/perfectsched/signal_thread.rb
+++ b/lib/perfectsched/signal_thread.rb
@@ -18,9 +18,8 @@
 
 module PerfectSched
 
-  # SignalQueue is obsolete because it does not run with ruby >= 2.0.0.
-  require 'perfectqueue/signal_queue'
-  SignalQueue = PerfectQueue::SignalQueue
+  require 'perfectqueue/signal_thread'
+  SignalThread = PerfectQueue::SignalThread
 
 end
 

--- a/lib/perfectsched/worker.rb
+++ b/lib/perfectsched/worker.rb
@@ -46,7 +46,7 @@ module PerfectSched
           @engine.shutdown
         end
       ensure
-        @sig.shutdown
+        @sig.stop
       end
       return nil
     rescue
@@ -130,28 +130,29 @@ module PerfectSched
     end
 
     def install_signal_handlers(&block)
-      SignalQueue.start do |sig|
-        sig.trap :TERM do
-          stop
+      s = self
+      SignalThread.new do |st|
+        st.trap :TERM do
+          s.stop
         end
-        sig.trap :INT do
-          stop
-        end
-
-        sig.trap :QUIT do
-          stop
+        st.trap :INT do
+          s.stop
         end
 
-        sig.trap :USR1 do
-          restart
+        st.trap :QUIT do
+          s.stop
         end
 
-        sig.trap :HUP do
-          restart
+        st.trap :USR1 do
+          s.restart
         end
 
-        sig.trap :USR2 do
-          logrotated
+        st.trap :HUP do
+          s.restart
+        end
+
+        st.trap :USR2 do
+          s.logrotated
         end
       end
     end

--- a/perfectsched.gemspec
+++ b/perfectsched.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "cron-spec", [">= 0.1.2", "<= 0.1.2"]
   gem.add_dependency "sequel", "~> 3.48.0"
   gem.add_dependency "tzinfo", "~> 0.3.29"
-  gem.add_dependency "perfectqueue", "~> 0.8.40"
+  gem.add_dependency "perfectqueue", "~> 0.8.41"
   gem.add_development_dependency "rake", "~> 0.9.2"
   gem.add_development_dependency "rspec", "~> 2.10.0"
   gem.add_development_dependency "simplecov", "~> 0.5.4"

--- a/spec/worker_spec.rb
+++ b/spec/worker_spec.rb
@@ -47,5 +47,12 @@ describe Worker do
     sleep 2
   end
 
+  it 'term signal' do
+    sleep 1
+    Process.kill(:TERM, Process.pid)
+    puts "finish expected..."
+    @thread.join
+  end
+
 end
 


### PR DESCRIPTION
This is needed for ruby >= 2.0.0. It requires perfectqueue 0.8.41.