### PR TITLE
fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ PerfectSched.open(config) {|sc|
     :next_time => Time.parse('2013-01-01 00:00:00 +0900').to_i,
     :data => data,
   }
-  sc.submit("sched-id", "type1", options)
+  sc.add("sched-id", "type1", options)
 }
 ```
 


### PR DESCRIPTION
Fixed a typo in Example section.

PerfectSched::ScheduleCollection#submit was renamed to #add at
https://github.com/treasure-data/perfectsched/commit/6dee6d6eab79dbb10888833713eb5cdb90f5be79